### PR TITLE
Fix efi && linter hints

### DIFF
--- a/roles/arch2disk/tasks/boot_setup.yml
+++ b/roles/arch2disk/tasks/boot_setup.yml
@@ -17,7 +17,7 @@
   tags:
     - initramfs
 
-- name: Re-generate initframfs
+- name: Re-generate initframfs  # noqa no-handler
   command: arch-chroot /mnt mkinitcpio -p linux
   when: mkinitcpio_hooks_adjust.changed
   tags:

--- a/roles/arch2disk/tasks/derive_facts.yml
+++ b/roles/arch2disk/tasks/derive_facts.yml
@@ -25,7 +25,7 @@
 - name: Verify UEFI boot mode
   fail:
     msg: System is required to boot with efi
-  when: efivars_stat.stat.exists
+  when: not efivars_stat.stat.exists
   tags:
     - arch2disk
     - efi_vars_check

--- a/roles/arch2disk/tasks/derive_facts.yml
+++ b/roles/arch2disk/tasks/derive_facts.yml
@@ -114,7 +114,7 @@
 # TODO maybe this is doable with ansible facts?
 
 # What we do here is to query the route to the control machine (ssh client IP)
-- name: Currently used network interface
+- name: Currently used network interface  # noqa command-instead-of-shell
   shell: "ip route get {{ ansible_env.SSH_CONNECTION | regex_search('^([^ ]+) ', '\\1') | first }}"
   changed_when: false
   register: network_interface

--- a/roles/arch2disk/tasks/localization.yml
+++ b/roles/arch2disk/tasks/localization.yml
@@ -9,7 +9,7 @@
   tags:
     - set_time
 
-- name: Set hardware clock
+- name: Set hardware clock  # noqa no-changed-when
   command: arch-chroot /mnt hwclock --systohc
   tags:
     - set_time
@@ -22,7 +22,7 @@
   tags:
     - locales
 
-- name: Generate locales, step 2/2
+- name: Generate locales, step 2/2  # noqa no-changed-when
   command: arch-chroot /mnt locale-gen
   tags:
     - locales

--- a/roles/arch2disk/tasks/main.yml
+++ b/roles/arch2disk/tasks/main.yml
@@ -12,7 +12,7 @@
     - boot_check
     - quick_exit
 
-- name: Synchronize clock via NTP
+- name: Synchronize clock via NTP  # noqa no-changed-when
   command: timedatectl set-ntp true
   tags:
     - arch2disk
@@ -50,7 +50,7 @@
 
 # Would be nice to have a script doing this without a country code
 # AUR pkg rate-arch-mirrors takes too long to compile+install...
-- name: Use rankmirrors to filter the fastest mirrors that support HTTPS # noqa risky-shell-pipe
+- name: Use rankmirrors to filter the fastest mirrors that support HTTPS # noqa risky-shell-pipe no-changed-when
   shell: >
     curl -s "https://archlinux.org/mirrorlist/?protocol=https&use_mirror_status=on&country={{ locale_country|upper }}"
     | sed -e 's/^#Server/Server/' -e '/^#/d'
@@ -75,6 +75,8 @@
     python pyalpm
     dosfstools btrfs-progs
     --noprogressbar
+  args:
+    creates: /mnt/usr/bin/nano  # Among others of course...
   tags:
     - arch2disk
     - pacstrap
@@ -82,6 +84,8 @@
 - name: Install base development tools # noqa risky-shell-pipe
   # pacstrap doesn't like groups
   shell: arch-chroot /mnt bash -c "yes '' | pacman -S base-devel --noconfirm"
+  args:
+    creates: /mnt/usr/bin/make  # One of the things installed...
   tags:
     - arch2disk
     - pacstrap
@@ -89,9 +93,9 @@
 
 # I now about the Ansible module to do this
 # But that would need about a thousands lines more, and is more error-prone
-# TODO this didn't work in test...
 - name: Generate fstab
   shell: genfstab -U /mnt >> /mnt/etc/fstab
+  # TODO this task doesn't warrant idempotency
   tags:
     - arch2disk
     - fstab

--- a/roles/arch2disk/tasks/networking.yml
+++ b/roles/arch2disk/tasks/networking.yml
@@ -30,6 +30,9 @@
       wifi.scan-rand-mac-address=yes
       [connection-mac-randomization]
       wifi.cloned-mac-address=stable
+    mode: 0644
+    owner: root
+    group: root
   tags:
     - networkmanager
     - wifi
@@ -37,6 +40,8 @@
 # Enable NetworkManager
 - name: Enable NetworkManager
   command: arch-chroot /mnt systemctl enable NetworkManager.service
+  args:
+    creates: /mnt/etc/systemd/system/multi-user.target.wants/NetworkManager.service
   tags:
     - networkmanager
 
@@ -54,5 +59,7 @@
 # Enable SSH server
 - name: Enable sshd
   command: arch-chroot /mnt systemctl enable sshd
+  args:
+    creates: /mnt/etc/systemd/system/multi-user.target.wants/sshd.service
   tags:
     - sshd

--- a/roles/arch2disk/tasks/partitioning.yml
+++ b/roles/arch2disk/tasks/partitioning.yml
@@ -77,6 +77,7 @@
       umount /mnt
 
 - name: Mount everything
+  # TODO this task may also have a problem with idempotency
   shell: >
       mount -o subvol=root,compress-force=zstd:{{ btrfs_compression_level }},space_cache,noatime,X-mount.mkdir,defaults
       {{ root_partition }} /mnt

--- a/roles/arch2disk/tasks/user_setup.yml
+++ b/roles/arch2disk/tasks/user_setup.yml
@@ -11,7 +11,7 @@
   tags:
     - root_passwd
 
-- name: Set root password # noqa risky-shell-pipe
+- name: Set root password # noqa risky-shell-pipe no-changed-when
   shell: echo "root:{{ rootpasswd }}" | chpasswd
   tags:
     - root_passwd


### PR DESCRIPTION
- Fix efi fail
- Disable some linter hints
- Add some "creates" to args command tasks, which should warrant idempotency and therefore silence some linter hints
- Specify file permissions for nm config
- Add todos where to fix linter hints later